### PR TITLE
Patches vulnerability introduced by transitive module - @certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slack_bolt==1.18.1
+slack_bolt==1.19.0
 python_dotenv==1.0.1
 gunicorn==22.0.0
 flask==3.0.3
@@ -6,7 +6,7 @@ requests==2.32.3
 pyjwt==2.8.0
 gql==3.5.0
 requests-toolbelt==1.0.0
-certifi>=2024.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
+certifi>=2024.6.2 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
 werkzeug>=3.0.3 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.2.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=switcherapi_switcher-slack-app
 sonar.projectName=switcher-slack-app
-sonar.projectVersion=2.0.0
+sonar.projectVersion=2.0.1
 sonar.organization=switcherapi
 sonar.links.homepage=https://github.com/switcherapi/switcher-slack-app
 

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -7,4 +7,4 @@ load_dotenv()
 SWITCHER_URL = os.environ.get("SWITCHER_URL")
 SWITCHER_API_URL = os.environ.get("SWITCHER_API_URL")
 RELEASE_TIME = os.environ.get("RELEASE_TIME", "latest")
-VERSION = f"2.0.0 {RELEASE_TIME}"
+VERSION = f"2.0.1 {RELEASE_TIME}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-slack_bolt==1.18.1
+slack_bolt==1.19.0
 python_dotenv==1.0.1
 gunicorn==22.0.0
 flask==3.0.3
@@ -6,6 +6,6 @@ requests==2.32.3
 pyjwt==2.8.0
 gql==3.5.0
 requests-toolbelt==1.0.0
-pytest==8.2.1
+pytest==8.2.2
 pytest-cov==5.0.0
 pytest-dotenv==0.5.2


### PR DESCRIPTION
Introduced through
    certifi@2021.10.8, requests@2.27.1 and others
    Fixed in
    certifi@2023.7.22

    Exploit maturity
    No known exploit

Detailed paths and remediation

    Introduced through: project@0.0.0 › certifi@2021.10.8
    Fix: Upgrade certifi to version 2023.7.22

Introduced through: project@0.0.0 › requests@2.27.1 › certifi@2021.10.8
Fix: Pin certifi to version 2023.7.22
Introduced through: project@0.0.0 › requests-toolbelt@1.0.0 › requests@2.27.1 › certifi@2021.10.8
Fix: Pin certifi to version 2023.7.22

Security information
Factors contributing to the scoring:

    Snyk: [CVSS 9.8](https://security.snyk.io/vuln/SNYK-PYTHON-CERTIFI-5805047) - Critical Severity
    NVD: [CVSS 9.8](https://nvd.nist.gov/vuln/detail/CVE-2023-37920) - Critical Severity