### PR TITLE
fix: graphQl schema fetch causes DIRECTIVE_DEFINITION error

### DIFF
--- a/src/services/switcher_client.py
+++ b/src/services/switcher_client.py
@@ -92,7 +92,7 @@ class SwitcherClient:
 
     def __gql_client__(self, resource: str) -> Client:
         return Client(
-            fetch_schema_from_transport = True,
+            fetch_schema_from_transport = False,
             transport = RequestsHTTPTransport(
                 url = f'{self._api_url}/slack-graphql',
                 headers = {


### PR DESCRIPTION
This pull request includes a small but important configuration change to the GraphQL client in `src/services/switcher_client.py`. The change disables schema fetching from the transport layer, which can improve client initialization speed and reduce unnecessary network requests.

- Configuration Change:
  * Set `fetch_schema_from_transport` to `False` in the `__gql_client__` method to prevent fetching the schema from the transport when initializing the GraphQL client.

# Cause
When using fetch_schema_from_transport=True in the Python gql library, the client performs an introspection query to fetch the schema from the server, which can result in a DIRECTIVE_DEFINITION (a DirectiveDefinition AST node) being returned in the schema's AST

*logs*
```
[2026-05-08 02:44:58 +0000] [7] [ERROR] slack_app.py:selection_domain: Error opening change request form: deprecated locations must be specified as a collection of DirectiveLocation enum values.
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/graphql/type/directives.py", line 68, in __init__
    locations = tuple(
                ^^^^^
  File "/usr/local/lib/python3.14/site-packages/graphql/type/directives.py", line 72, in <genexpr>
    else DirectiveLocation[cast(str, value)]
         ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/enum.py", line 775, in __getitem__
    return cls._member_map_[name]
           ~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'DIRECTIVE_DEFINITION'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/app/controller/change_request.py", line 42, in on_domain_selected
    envs = SwitcherService().get_environments(team_id, domain_id or "") or []
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/services/switcher_service.py", line 33, in get_environments
    response: dict = self.do_graphql(f'''
                     ~~~~~~~~~~~~~~~^^^^^
        query {{
        ^^^^^^^^
    ...<6 lines>...
        }}
        ^^
    ''')
    ^^^^
  File "/home/app/services/switcher_client.py", line 65, in do_graphql
    return client.execute(query)
           ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 497, in execute
    return self.execute_sync(
           ~~~~~~~~~~~~~~~~~^
        request,
        ^^^^^^^^
    ...<3 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 247, in execute_sync
    with self as session:
         ^^^^
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 853, in __enter__
    return self.connect_sync()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 832, in connect_sync
    self.session.fetch_schema()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 1265, in fetch_schema
    self.client._build_schema_from_introspection(execution_result)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 184, in _build_schema_from_introspection
    self.schema = build_client_schema(self.introspection)
                  ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/gql/utilities/build_client_schema.py", line 95, in build_client_schema
    return build_client_schema_orig(introspection, assume_valid=False)
  File "/usr/local/lib/python3.14/site-packages/graphql/utilities/build_client_schema.py", line 415, in build_client_schema
    build_directive(directive_introspection)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/graphql/utilities/build_client_schema.py", line 370, in build_directive
    return GraphQLDirective(
        name=directive_introspection["name"],
    ...<8 lines>...
        args=build_argument_def_map(directive_introspection["args"]),
    )
  File "/usr/local/lib/python3.14/site-packages/graphql/type/directives.py", line 77, in __init__
    raise TypeError(
    ...<2 lines>...
    )
TypeError: deprecated locations must be specified as a collection of DirectiveLocation enum values.
```